### PR TITLE
[REFACTOR] 채널 API 갱신하기 버튼 mew mocking 응답 수정 및 린트&프리티어 적용

### DIFF
--- a/src/components/channel/userProfile/index.tsx
+++ b/src/components/channel/userProfile/index.tsx
@@ -37,10 +37,20 @@ const UserProfile = ({ onRefresh, isRefreshing }: UserProfileProps) => {
           disabled={isRefreshing}
           className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-[#7C5CFF] text-white typo-body5 cursor-pointer hover:bg-[#6344DD] disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          <svg className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <path d="M21 12a9 9 0 11-2.2-5.9M21 3v5h-5" strokeLinecap="round" strokeLinejoin="round"/>
+          <svg
+            className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path
+              d="M21 12a9 9 0 11-2.2-5.9M21 3v5h-5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </svg>
-          {isRefreshing ? '갱신 중...' : '강제 갱신'}
+          {isRefreshing ? '갱신 중...' : '갱신 하기'}
         </button>
       )}
     </div>

--- a/src/mocks/data/analysisMock.ts
+++ b/src/mocks/data/analysisMock.ts
@@ -139,3 +139,24 @@ export const mockChannelAnalysisResponse = {
   ],
   percentileDataCollectedAt: '2026-05-04T05:32:04.674274+00:00',
 };
+
+/** force=true 갱신 시 반환할 mock (점수·수집 시각 변경) */
+export const mockChannelAnalysisForceRefreshResponse = {
+  ...mockChannelAnalysisResponse,
+  channelScore: {
+    ...mockChannelAnalysisResponse.channelScore,
+    overall: 72,
+    topPercent: 28,
+    comment:
+      '강제 갱신 후 도달력이 소폭 개선되었습니다. 시청자 반응과 콘텐츠 만족도는 여전히 높은 수준을 유지하고 있습니다.',
+    factors: mockChannelAnalysisResponse.channelScore.factors.map(factor =>
+      factor.name === '도달력' ? { ...factor, score: 63 } : factor,
+    ),
+  },
+  summary: {
+    ...mockChannelAnalysisResponse.summary,
+    avgViewCountChange: 4.1,
+    uploadFrequencyChange: -1.5,
+  },
+  percentileDataCollectedAt: new Date().toISOString(),
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,6 +1,9 @@
 import { http, HttpResponse } from 'msw';
 import { mockRecommendResponse, mockScriptResponse } from '@/mocks/data/recommendMock';
-import { mockChannelAnalysisResponse } from '@/mocks/data/analysisMock';
+import {
+  mockChannelAnalysisResponse,
+  mockChannelAnalysisForceRefreshResponse,
+} from '@/mocks/data/analysisMock';
 import { mockVideoAnalysisResponse } from '@/mocks/data/videoAnalysisMock';
 import { mockKeywordsResponse } from '@/mocks/data/keywordsMock';
 
@@ -22,9 +25,16 @@ export const handlers = [
     return HttpResponse.json(mockScriptResponse, { status: 200 });
   }),
 
-  // GET /analyze/channel - 채널 분석 요청
-  http.get(`${SERVER_URL}/analyze/channel`, () => {
-    return HttpResponse.json(mockChannelAnalysisResponse, { status: 200 });
+  // GET /analyze/channel - 채널 분석 요청 (force=true 시 갱신 데이터)
+  http.get(`${SERVER_URL}/analyze/channel`, async ({ request }) => {
+    const force = new URL(request.url).searchParams.get('force') === 'true';
+    if (force) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+    return HttpResponse.json(
+      force ? mockChannelAnalysisForceRefreshResponse : mockChannelAnalysisResponse,
+      { status: 200 },
+    );
   }),
 
   // GET /analyze/video/:videoId - 영상 상세 분석 요청


### PR DESCRIPTION
## ✨ 변경 내용

- 채널 API 갱신하기 버튼 mew mocking 응답 수정 : 점수 변경 및 setTimeout 1초 적용 (1000)
- 린트&프리티어 적용

---

## 📸 스크린샷 (선택)

UI 변경이 있다면 스크린샷을 첨부해주세요.

---

## ✅ 체크리스트

- [ ] 코드에 불필요한 주석 / console 제거
- [ ] eslint / prettier 통과
- [ ] 테스트 정상 동작 확인
- [ ] 관련 문서 및 주석 업데이트
