### PR TITLE
[FEAT] 롱폼·숏폼 videoType API 연동 및 제목 재생성 기능 추가

### DIFF
--- a/src/api/command.ts
+++ b/src/api/command.ts
@@ -1,20 +1,24 @@
 import api from './axios';
 
+export type VideoType = 'long' | 'short';
+
 // ===== Request Types =====
 
 interface RecommendRequest {
   requestURL: string;
   keywords: string;
   category: string;
+  videoType: VideoType;
 }
 
 interface ScriptRequest {
   requestURL: string;
   keywords: string;
   category: string;
-  time: number;
+  time?: number | null;
   title: string;
   concept: string;
+  videoType: VideoType;
 }
 
 // ===== Response Types =====
@@ -29,6 +33,7 @@ export interface VideoAnalysisResponse {
     category: string;
     keyword: string;
     durationSeconds: number;
+    videoType: VideoType;
     score: {
       overall: number;
       topPercent: number;
@@ -79,6 +84,26 @@ export interface VideoAnalysisResponse {
 
 // ===== API Functions =====
 
+const serializeScriptParams = (params: Record<string, string | number | null>) =>
+  Object.entries(params)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) =>
+      value === null
+        ? `${encodeURIComponent(key)}=null`
+        : `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`,
+    )
+    .join('&');
+
+const buildScriptParams = (data: ScriptRequest): Record<string, string | number | null> => ({
+  requestURL: data.requestURL,
+  title: data.title,
+  concept: data.concept,
+  keywords: data.keywords,
+  category: data.category,
+  videoType: data.videoType,
+  time: data.videoType === 'short' ? null : (data.time ?? null),
+});
+
 // POST /login_guest - 비회원(guest) 토큰 발급
 export const postGuestLogin = async (): Promise<{ guestToken: string }> => {
   const response = await api.post('/login_guest');
@@ -90,6 +115,7 @@ export const postRecommend = async (data: RecommendRequest) => {
   const params: Record<string, string> = {
     keywords: data.keywords,
     category: data.category,
+    videoType: data.videoType,
   };
   if (data.requestURL) {
     params.requestURL = data.requestURL;
@@ -101,14 +127,19 @@ export const postRecommend = async (data: RecommendRequest) => {
 // POST /ai_script - AI 제목/스크립트 요청
 export const postScript = async (data: ScriptRequest) => {
   const response = await api.post('/ai_script', null, {
-    params: {
-      requestURL: data.requestURL,
-      title: data.title,
-      concept: data.concept,
-      keywords: data.keywords,
-      category: data.category,
-      time: data.time,
-    },
+    params: buildScriptParams(data),
+    paramsSerializer: serializeScriptParams,
+  });
+  return response.data;
+};
+
+// POST /ai_titleResearch - AI 추천 제목 1개 재생성
+export const postTitleResearch = async (
+  data: ScriptRequest,
+): Promise<{ suggestedTitle: string }> => {
+  const response = await api.post('/ai_titleResearch', null, {
+    params: buildScriptParams(data),
+    paramsSerializer: serializeScriptParams,
   });
   return response.data;
 };

--- a/src/components/channel/guideChannel/guideItem/index.tsx
+++ b/src/components/channel/guideChannel/guideItem/index.tsx
@@ -52,13 +52,15 @@ const GuideItem = ({ comment, subcomment, metric, current, target, benchmark }: 
       : 0;
 
   return (
-    <div className="flex w-full px-5 py-5 justify-start items-start gap-2.5 self-stretch rounded-xl bg-[#F5EFFF]">
+    <div className="flex flex-1 self-stretch px-5 py-5 items-stretch gap-2.5 rounded-xl bg-[#F5EFFF]">
       <CommentIcon className="shrink-0 mt-0.5" />
-      <div className="flex w-full flex-col gap-2">
-        <div className="flex w-full justify-start text-black typo-body4-semibold">{comment}</div>
-        <div className="flex w-full justify-start text-[#555] typo-body5">{subcomment}</div>
+      <div className="flex flex-1 flex-col justify-between gap-4">
+        <div className="flex flex-col gap-2">
+          <div className="flex w-full justify-start text-black typo-body4-semibold">{comment}</div>
+          <div className="flex w-full justify-start text-[#555] typo-body5">{subcomment}</div>
+        </div>
         {metric && benchmark && current != null && (
-          <div className="flex flex-col gap-1.5 mt-2">
+          <div className="flex flex-col gap-1.5">
             <div className="flex justify-between items-center">
               <span className="text-xs text-[#717171]">{metricLabels[metric] ?? metric}</span>
               <span className="text-xs font-semibold text-[#7C5CFF]">

--- a/src/components/channel/guideChannel/index.tsx
+++ b/src/components/channel/guideChannel/index.tsx
@@ -14,7 +14,7 @@ const GuideChannel = () => {
           이렇게 해보세요! {data?.channel?.name ?? 'name'}님 맞춤 CRiT 가이드
         </div>
       </div>
-      <div className="flex w-full gap-8 justify-center items-center">
+      <div className="flex w-full gap-8 justify-center items-stretch">
         {guides.length > 0 ? (
           guides.map((guide, i) => (
             <GuideItem

--- a/src/components/channel/userProfile/index.tsx
+++ b/src/components/channel/userProfile/index.tsx
@@ -1,4 +1,5 @@
 import useChannelStore from '@/stores/useChannelStore';
+import CritLogo from '@/assets/icons/critLogo.svg?react';
 
 interface UserProfileProps {
   onRefresh?: () => void;
@@ -12,14 +13,14 @@ const UserProfile = ({ onRefresh, isRefreshing }: UserProfileProps) => {
   return (
     <div className="flex w-full h-39 justify-between items-center gap-8 px-6 py-4 rounded-xl border border-[#A594F9]">
       <div className="flex items-center gap-8">
-        <div className="w-30 h-30 rounded-full bg-gray-500 overflow-hidden shrink-0">
-          {channel?.profileImageUrl && (
+        <div className="w-30 h-30 rounded-full bg-[radial-gradient(circle,#ffffff_0%,#CDC1FF_100%)] overflow-hidden shrink-0">
+          {(channel?.profileImageUrl && (
             <img
               src={channel.profileImageUrl}
               alt={channel.name}
               className="w-full h-full object-cover"
             />
-          )}
+          )) || <CritLogo className="w-30 h-30 object-cover" />}
         </div>
         <div className="flex flex-col justify-start gap-3">
           <div className="w-full typo-title2 text-black">{channel?.name ?? 'channel ID'}</div>

--- a/src/components/recommendContent/formAnswer/scriptEditor/index.tsx
+++ b/src/components/recommendContent/formAnswer/scriptEditor/index.tsx
@@ -24,14 +24,16 @@ const ScriptEditor = () => {
       <div className="flex flex-1 flex-col gap-4 animate-fade-in-up">
         <div className="flex w-full typo-title-bold text-[#0A0A0A] items-stretch">AI 대본 초안</div>
         <div className="relative group w-full flex-1 min-h-0">
-          <div className="h-full overflow-y-auto px-3 py-4 rounded-xl bg-[#FAFAFA] border border-[#A594F9] typo-body4-semibold text-black whitespace-pre-line break-keep leading-6 script-scroll">
-            {script ? (
-              formatScript(script)
-            ) : (
-              <span className="animate-loading-pulse text-gray-400">
-                검색 후 대본이 표시됩니다.
-              </span>
-            )}
+          <div className="h-full rounded-xl bg-[#FAFAFA] border border-[#A594F9] py-4 px-3">
+            <div className="h-full overflow-y-auto typo-body4-semibold text-black whitespace-pre-line break-keep leading-6 script-scroll">
+              {script ? (
+                formatScript(script)
+              ) : (
+                <span className="animate-loading-pulse text-gray-400">
+                  검색 후 대본이 표시됩니다.
+                </span>
+              )}
+            </div>
           </div>
           {script && (
             <button

--- a/src/components/recommendContent/formAnswer/videoTitle/index.tsx
+++ b/src/components/recommendContent/formAnswer/videoTitle/index.tsx
@@ -1,15 +1,61 @@
+import { useState } from 'react';
 import VideoTitleItem from '@/components/recommendContent/formAnswer/videoTitle/videoTitleItem';
 import useAIFormStore from '@/stores/useAIFormStore';
+import useRecommendStore from '@/stores/useRecommendStore';
+import { postTitleResearch } from '@/api/command';
+import { useShallow } from 'zustand/react/shallow';
 
 const VideoTitle = () => {
   const data = useAIFormStore(s => s.data);
+  const updateSuggestedTitle = useAIFormStore(s => s.updateSuggestedTitle);
+  const { formInput, recommendations, selectedSubjectIndex } = useRecommendStore(
+    useShallow(s => ({
+      formInput: s.formInput,
+      recommendations: s.recommendations,
+      selectedSubjectIndex: s.selectedSubjectIndex,
+    })),
+  );
+  const [regeneratingIndex, setRegeneratingIndex] = useState<number | null>(null);
+
   const titles = data?.suggestedTitles ?? [];
+  const subject = selectedSubjectIndex != null ? recommendations[selectedSubjectIndex] : null;
+
+  const handleRegenerate = async (index: number) => {
+    if (!data || !titles[index]) return;
+
+    setRegeneratingIndex(index);
+
+    try {
+      const res = await postTitleResearch({
+        requestURL: formInput.requestURL,
+        title: titles[index],
+        concept: subject?.conceptSummary ?? '',
+        keywords: formInput.keywords,
+        category: formInput.category,
+        videoType: formInput.videoType,
+        time: formInput.videoType === 'short' ? null : formInput.time,
+      });
+
+      updateSuggestedTitle(index, res.suggestedTitle);
+    } catch (err) {
+      console.error('제목 재생성 요청 실패:', err);
+    } finally {
+      setRegeneratingIndex(null);
+    }
+  };
 
   return (
     <div className="inline-flex w-full py-6 pl-6 pr-5 flex-col items-start gap-5 rounded-xl bg-[#fff] border border-[#A594F9]">
       <div className="flex w-full typo-title-bold text-[#0A0A0A] items-stretch">AI 추천 제목</div>
       {titles.length > 0
-        ? titles.map((title, i) => <VideoTitleItem key={i} title={title} />)
+        ? titles.map((title, i) => (
+            <VideoTitleItem
+              key={i}
+              title={title}
+              isRegenerating={regeneratingIndex === i}
+              onRegenerate={() => handleRegenerate(i)}
+            />
+          ))
         : [0, 1, 2].map(i => <VideoTitleItem key={i} title="" />)}
     </div>
   );

--- a/src/components/recommendContent/formAnswer/videoTitle/videoTitleItem/index.tsx
+++ b/src/components/recommendContent/formAnswer/videoTitle/videoTitleItem/index.tsx
@@ -1,33 +1,63 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import CopyIcon from '@/assets/icons/copy-icon.svg?react';
 import RefreshIcon from '@/assets/icons/refresh-icon.svg?react';
 
 interface VideoTitleProps {
   title: string;
-  onRegenerate?: () => void;
+  isRegenerating?: boolean;
+  onRegenerate?: () => void | Promise<void>;
 }
 
-const VideoTitle = ({ title, onRegenerate }: VideoTitleProps) => {
+const FADE_DURATION_MS = 300;
+
+const VideoTitle = ({ title, isRegenerating = false, onRegenerate }: VideoTitleProps) => {
   const [copied, setCopied] = useState(false);
-  const [regenerating, setRegenerating] = useState(false);
+  const [displayTitle, setDisplayTitle] = useState(title);
+  const [opacity, setOpacity] = useState(1);
+  const prevTitleRef = useRef(title);
+
+  useEffect(() => {
+    if (title === prevTitleRef.current) return;
+
+    const prevTitle = prevTitleRef.current;
+    prevTitleRef.current = title;
+
+    if (!prevTitle && title) {
+      setDisplayTitle(title);
+      return;
+    }
+
+    setOpacity(0);
+
+    const timer = window.setTimeout(() => {
+      setDisplayTitle(title);
+      requestAnimationFrame(() => setOpacity(1));
+    }, FADE_DURATION_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [title]);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(title);
+    navigator.clipboard.writeText(displayTitle);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
 
   const handleRegenerate = () => {
-    setRegenerating(true);
-    onRegenerate?.();
-    setTimeout(() => setRegenerating(false), 2000);
+    if (isRegenerating || !onRegenerate) return;
+    onRegenerate();
   };
+
+  const formattedTitle = displayTitle ? displayTitle.replace(/\(/g, '\n(') : '';
 
   return (
     <div className="flex py-3 px-4 justify-end items-center gap-10 self-stretch rounded-xl border border-[#A594F9] bg-[#FAFAFA]">
-      <div className="w-64 typo-body4-semibold text-black whitespace-pre-line">
-        {title ? (
-          title.replace(/\(/g, '\n(')
+      <div
+        className="w-64 typo-body4-semibold text-black whitespace-pre-line transition-opacity ease-in-out"
+        style={{ opacity, transitionDuration: `${FADE_DURATION_MS}ms` }}
+      >
+        {displayTitle ? (
+          formattedTitle
         ) : (
           <span className="text-gray-400 animate-loading-pulse">제목을 생성하고 있습니다...</span>
         )}
@@ -42,10 +72,10 @@ const VideoTitle = ({ title, onRegenerate }: VideoTitleProps) => {
         </div>
         <div
           onClick={handleRegenerate}
-          className={`flex justify-end items-center gap-1.5 cursor-pointer ${regenerating ? 'text-[#6B4EFF]' : 'text-[#0a0a0a89] active:text-[#6B4EFF]'}`}
+          className={`flex justify-end items-center gap-1.5 ${isRegenerating || !onRegenerate ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'} ${isRegenerating ? 'text-[#6B4EFF]' : 'text-[#0a0a0a89] active:text-[#6B4EFF]'}`}
         >
-          <RefreshIcon className={`w-4 h-4 ${regenerating ? 'animate-spin' : ''}`} />
-          <div className="typo-label">{regenerating ? '생성 중' : '다시생성'}</div>
+          <RefreshIcon className={`w-4 h-4 ${isRegenerating ? 'animate-spin' : ''}`} />
+          <div className="typo-label">{isRegenerating ? '생성 중' : '다시생성'}</div>
         </div>
       </div>
     </div>

--- a/src/components/recommendContent/formList/index.tsx
+++ b/src/components/recommendContent/formList/index.tsx
@@ -69,7 +69,7 @@ const FormList = ({ onSearch, initialKeyword = '' }: FormListProps) => {
     if (contentRef.current) {
       setContentHeight(contentRef.current.scrollHeight);
     }
-  }, []);
+  }, [formInput.videoType]);
 
   const handleCategoryToggle = (category: string, checked: boolean) => {
     setSelectedCategories(prev =>
@@ -87,7 +87,7 @@ const FormList = ({ onSearch, initialKeyword = '' }: FormListProps) => {
     const missing: string[] = [];
     if (!keyword.trim()) missing.push('Keyword');
     if (selectedCategories.length === 0) missing.push('Category');
-    if (time === 0) missing.push('Time');
+    if (formInput.videoType === 'long' && time === 0) missing.push('Time');
 
     if (missing.length > 0) {
       setErrorMsg(`${missing.join(', ')}을(를) 입력해주세요.`);
@@ -105,13 +105,15 @@ const FormList = ({ onSearch, initialKeyword = '' }: FormListProps) => {
         requestURL,
         keywords: keyword,
         category: `{${selectedCategories.join(', ')}}`,
+        videoType: formInput.videoType,
       });
       setRecommendations(res);
       setFormInput({
         requestURL,
         keywords: keyword,
         category: `{${selectedCategories.join(', ')}}`,
-        time,
+        time: formInput.videoType === 'long' ? time : null,
+        videoType: formInput.videoType,
       });
 
       onSearch?.();
@@ -192,16 +194,18 @@ const FormList = ({ onSearch, initialKeyword = '' }: FormListProps) => {
                 ))}
               </div>
             </div>
-            <div className="flex w-196 flex-col items-start gap-4">
-              <div className="typo-body1-medium text-[#0A0A0A]">Time</div>
-              <div className="flex w-full items-center justify-between">
+            {formInput.videoType === 'long' && (
+              <div className="flex w-196 flex-col items-start gap-4">
+                <div className="typo-body1-medium text-[#0A0A0A]">Time</div>
                 <TimeSlider value={time} onChange={setTime} />
-                <div
-                  onClick={handleReset}
-                  className="flex py-1.5 px-3 justify-center items-center rounded-md bg-[#FF6B6B] hover:bg-[#FF4757] active:bg-[#FF8787] typo-label text-white cursor-pointer transition-colors"
-                >
-                  초기화
-                </div>
+              </div>
+            )}
+            <div className="flex w-196 justify-end">
+              <div
+                onClick={handleReset}
+                className="flex py-1.5 px-3 justify-center items-center rounded-md bg-[#FF6B6B] hover:bg-[#FF4757] active:bg-[#FF8787] typo-label text-white cursor-pointer transition-colors"
+              >
+                초기화
               </div>
             </div>
           </div>

--- a/src/components/recommendContent/formSubject/index.tsx
+++ b/src/components/recommendContent/formSubject/index.tsx
@@ -12,10 +12,11 @@ interface FormSubjectProps {
 const FormSubject = ({ onSelect }: FormSubjectProps) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const [contentHeight, setContentHeight] = useState<number | undefined>(undefined);
-  const { recommendations, formInput } = useRecommendStore(
+  const { recommendations, formInput, setSelectedSubjectIndex } = useRecommendStore(
     useShallow(s => ({
       recommendations: s.recommendations,
       formInput: s.formInput,
+      setSelectedSubjectIndex: s.setSelectedSubjectIndex,
     })),
   );
   const setData = useAIFormStore(s => s.setData);
@@ -37,6 +38,7 @@ const FormSubject = ({ onSelect }: FormSubjectProps) => {
 
   const handleClick = async (index: number) => {
     setSelectedIndex(index);
+    setSelectedSubjectIndex(index);
     setCollapsed(true);
 
     const item = recommendations[index];
@@ -50,7 +52,8 @@ const FormSubject = ({ onSelect }: FormSubjectProps) => {
         concept,
         keywords: formInput.keywords,
         category: formInput.category,
-        time: formInput.time,
+        videoType: formInput.videoType,
+        time: formInput.videoType === 'short' ? null : formInput.time,
       });
       const item = res[0] ?? res;
       setData({

--- a/src/components/recommendContent/tabList/index.tsx
+++ b/src/components/recommendContent/tabList/index.tsx
@@ -3,28 +3,32 @@ import { useState } from 'react';
 interface TabListProps {
   tabs: string[];
   defaultTab?: number;
+  activeIndex?: number;
   onChange?: (index: number) => void;
 }
 
-const TabList = ({ tabs, defaultTab = 0, onChange }: TabListProps) => {
-  const [activeIndex, setActiveIndex] = useState(defaultTab);
+const TabList = ({ tabs, defaultTab = 0, activeIndex, onChange }: TabListProps) => {
+  const [internalIndex, setInternalIndex] = useState(defaultTab);
+  const currentIndex = activeIndex ?? internalIndex;
 
   const handleClick = (index: number) => {
-    setActiveIndex(index);
+    if (activeIndex === undefined) {
+      setInternalIndex(index);
+    }
     onChange?.(index);
   };
 
   return (
     <div className="relative flex w-155 h-16 px-4 py-0.5 justify-center items-center rounded-xl opacity-90 bg-[#6B4EFF]">
       <div
-        className={`absolute w-72 h-11 rounded-xl bg-white transition-transform duration-300 ease-in-out ${activeIndex === 0 ? 'tab-indicator-left' : 'tab-indicator-right'}`}
+        className={`absolute w-72 h-11 rounded-xl bg-white transition-transform duration-300 ease-in-out ${currentIndex === 0 ? 'tab-indicator-left' : 'tab-indicator-right'}`}
       />
       {tabs.map((tab, index) => (
         <div
           key={index}
           onClick={() => handleClick(index)}
           className={`relative z-10 flex w-73 h-15 justify-center items-center rounded-xl cursor-pointer transition-colors duration-300
-            ${activeIndex === index ? 'typo-title-bold text-[#6B4EFF]' : 'typo-body1-medium text-white'}`}
+            ${currentIndex === index ? 'typo-title-bold text-[#6B4EFF]' : 'typo-body1-medium text-white'}`}
         >
           {tab}
         </div>

--- a/src/components/videoDetail/recommendContent/index.tsx
+++ b/src/components/videoDetail/recommendContent/index.tsx
@@ -32,15 +32,17 @@ const RecommendContent = () => {
   const [isLoadingScript, setIsLoadingScript] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
 
-  // 키워드, 카테고리는 videoInfo에서 가져옴
+  // 키워드, 카테고리, 영상 타입은 videoInfo에서 가져옴
   const keyword = videoAnalysis?.videoInfo?.keyword ?? '';
   const category = videoAnalysis?.videoInfo?.category ?? '';
+  const videoType = videoAnalysis?.videoInfo?.videoType ?? 'long';
+  const isShortForm = videoType === 'short';
 
   // 추천 결과
   const [recommendations, setRecommendations] = useState<RecommendItem[]>([]);
 
   const handleSearch = async () => {
-    if (time === 0) {
+    if (!isShortForm && time === 0) {
       setErrorMsg('영상 길이(Time)를 입력해주세요.');
       return;
     }
@@ -55,6 +57,7 @@ const RecommendContent = () => {
         requestURL: channelURL,
         keywords: keyword,
         category: category,
+        videoType,
       });
       setRecommendations(res.slice(0, 3)); // 주제 3개만
       setShowForm(false);
@@ -88,7 +91,8 @@ const RecommendContent = () => {
         concept,
         keywords: keyword,
         category: category,
-        time: time,
+        videoType,
+        time: isShortForm ? null : time,
       });
 
       const resultItem = res[0] ?? res;
@@ -110,7 +114,8 @@ const RecommendContent = () => {
         requestURL: channelURL,
         keywords: keyword,
         category: category,
-        time: time,
+        time: isShortForm ? null : time,
+        videoType,
       });
       setRecommendationsStore(recommendations);
       setSelectedSubjectIndex(index);
@@ -188,7 +193,13 @@ const RecommendContent = () => {
                   {/* 시간 설정 */}
                   <div className="flex flex-col w-[30%] gap-6">
                     <div className="text-black typo-body4-semibold">Time</div>
-                    <TimeSlider value={time} onChange={setTime} compact />
+                    {isShortForm ? (
+                      <div className="text-gray-400 animate-loading-pulse typo-body5">
+                        숏폼은 영상 길이를 설정할 수 없습니다.
+                      </div>
+                    ) : (
+                      <TimeSlider value={time} onChange={setTime} compact />
+                    )}
                   </div>
                 </div>
 

--- a/src/mocks/data/analysisMock.ts
+++ b/src/mocks/data/analysisMock.ts
@@ -1,162 +1,187 @@
 // Analysis 페이지 Mock 데이터
 
-export const mockChannelAnalysisResponse = {
-  channel: {
-    handle: '@CRiT',
-    profileImageUrl: '',
-    channelId: 'UCpJw2H9KKqwCCGQKRh1Bf2w',
-    name: 'CRiT',
-    subscriberCount: 100000000,
+const mockChannelProfile = {
+  handle: '@CRiT',
+  profileImageUrl: '',
+  channelId: 'UCpJw2H9KKqwCCGQKRh1Bf2w',
+  name: 'CRiT',
+  subscriberCount: 100000000,
+};
+
+const mockPercentileVideoAnalysis = [
+  {
+    videoId: 'VXEXCOUOOBM',
+    title: 'AI 추천 CRiT의 등장',
+    thumbnailUrl: '',
+    percentileScore: 51,
+    reason:
+      '콘텐츠 만족도이(가) 상위 7%로 뛰어나요. 도달력을(를) 개선하면 점수가 올라갈 수 있어요.',
   },
+  {
+    videoId: 'IT0mlafrYEM',
+    title: 'AI로 성장하는 인플루언서',
+    thumbnailUrl: '',
+    percentileScore: 65,
+    reason: '시청자 반응이(가) 상위 6%로 뛰어나요. 도달력을(를) 개선하면 점수가 올라갈 수 있어요.',
+  },
+  {
+    videoId: 'Ia5dP5DTR-8',
+    title: '수상할 정도로 카직스를 잘하는',
+    thumbnailUrl: '',
+    percentileScore: 61,
+    reason:
+      '콘텐츠 만족도이(가) 상위 14%로 뛰어나요. 도달력을(를) 개선하면 점수가 올라갈 수 있어요.',
+  },
+  {
+    videoId: 'adhfGPYJFtk',
+    title: '증바람',
+    thumbnailUrl: '',
+    percentileScore: 72,
+    reason: '콘텐츠 만족도이(가) 상위 26%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
+  },
+  {
+    videoId: 'k5UC25k6cK4',
+    title: '5년 만에 페이커 손에 쥐어진 총검',
+    thumbnailUrl: '',
+    percentileScore: 75,
+    reason: '콘텐츠 만족도이(가) 상위 15%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
+  },
+  {
+    videoId: '9-i2b4aCxLQ',
+    title: '화제의 페이커 암베사 정글 챌린지',
+    thumbnailUrl: '',
+    percentileScore: 58,
+    reason:
+      '콘텐츠 만족도이(가) 상위 11%로 뛰어나요. 도달력을(를) 개선하면 점수가 올라갈 수 있어요.',
+  },
+  {
+    videoId: 'Z7l05JEefxw',
+    title: '현준이 교육 들어갑니다',
+    thumbnailUrl: '',
+    percentileScore: 73,
+    reason: '콘텐츠 만족도이(가) 상위 10%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
+  },
+  {
+    videoId: 'JnnmPHpAbg0',
+    title: '신을 뵙습니다',
+    thumbnailUrl: '',
+    percentileScore: 74,
+    reason: '콘텐츠 만족도이(가) 상위 14%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
+  },
+  {
+    videoId: 'pkVtkP-TFuw',
+    title: '두바이 쫀득 구체',
+    thumbnailUrl: '',
+    percentileScore: 73,
+    reason: '콘텐츠 만족도이(가) 상위 14%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
+  },
+  {
+    videoId: 'EBO3CWo-81A',
+    title: '페즈리얼 많이 세다, 자기 전에 생각 많이 날거야',
+    thumbnailUrl: '',
+    percentileScore: 76,
+    reason: '콘텐츠 만족도이(가) 상위 17%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
+  },
+];
+
+export const mockChannelAnalysisResponse = {
+  channel: mockChannelProfile,
   channelScore: {
-    overall: 68,
-    topPercent: 32,
-    comment:
-      '시청자 반응과 만족도가 높은 점에 비해 도달력이 상대적으로 부족한 것이 종합 점수를 낮추고 있습니다.',
+    overall: 58,
+    topPercent: 42,
+    comment: '구독자 수가 적지만 시청자 반응이 좋은 편이며, 콘텐츠 만족도 개선이 필요해 보입니다.',
     factors: [
       {
-        score: 56,
+        weight: 40,
+        score: 69,
         name: '도달력',
         description: '구독자 대비 조회수',
-        weight: 60,
       },
       {
-        score: 84,
-        name: '시청자 반응',
-        description: '좋아요+댓글 비율',
-        weight: 25,
+        weight: 40,
+        score: 76,
+        name: '채널 평균 대비',
+        description: '채널 평소 성적 대비 상대 성과',
       },
       {
-        score: 87,
-        name: '콘텐츠 만족도',
-        description: '좋아요 비율',
-        weight: 15,
+        weight: 20,
+        score: 0,
+        name: '일평균 조회수',
+        description: '시간 대비 조회수 성장 속도',
       },
     ],
   },
   summary: {
-    avgViewCount: 314881.03507565334,
-    avgViewCountChange: 2.3,
-    uploadFrequencyPerWeek: 3.0,
-    uploadFrequencyChange: -3.0,
-    avgWatchDurationSeconds: null,
+    avgViewCount: 109.0,
+    avgViewCountChange: null,
+    uploadFrequencyPerWeek: 0.0,
+    uploadFrequencyChange: null,
+    avgWatchDurationSeconds: 0.0,
     avgWatchDurationChange: null,
-    subscriberChange: null,
-    subscriberChangePercent: null,
+    subscriberChange: 0,
+    subscriberChangePercent: 0.0,
+    isFirstAnalysis: true,
   },
   guides: [
     {
+      title: '시청자 반응 증진을 통한 영향력 확대',
       description:
-        '현재 평균 영상 길이가 9분인데, 7~10분 사이로 최적화하면 영상 도달력과 조회수가 15% 이상 증가할 것으로 예상됩니다.',
-      title: '조회수 향상을 위한 영상 길이 조정',
+        '시청자 반응(engagement) 지표는 현재 상위 25% 수준인 0.0367로 양호한 편입니다. 하지만 시청자 참여도를 더욱 높여 지속적인 채널 성장을 도모할 필요가 있습니다. 영상 내용의 흥미도와 가치성을 높이고, 시청자와의 상호작용을 강화하는 등의 노력으로 시청자 반응 지표를 개선해 나가세요.',
+      metric: 'engagement',
+      current: 0.03669724770642202,
+      target: 0.017719649825967725,
+      benchmark: {
+        p75: 0.017719649825967725,
+        p25: 0.008189655172413794,
+        p50: 0.012291294742664471,
+      },
     },
     {
+      title: '조회수 증대를 통한 콘텐츠 영향력 제고',
       description:
-        '현재 채널의 콘텐츠 만족도 점수가 50점이므로, 유사 주제의 영상 외에도 게임 튜토리얼, 챔피언 리뷰 등 새로운 유형의 영상을 시도해 보세요. 이를 통해 시청자층을 다양화하고 콘텐츠 만족도를 25% 이상 높일 수 있습니다.',
-      title: '영상 콘텐츠 다각화',
+        '채널의 평균 일일 조회수는 16회로 하위 25% 수준에 머물러 있습니다. 고퀄리티 콘텐츠 제작, 태그/제목/썸네일 최적화, 관련 동영상 및 플레이리스트 활용 등을 통해 조회수를 지속적으로 높여나가세요. 이를 통해 채널의 노출과 잠재적 구독자 기반을 확대할 수 있습니다.',
+      metric: 'dailyViews',
+      current: 15.571428571428571,
+      target: 549677.0,
+      benchmark: {
+        p75: 549677.0,
+        p25: 14604.0,
+        p50: 57639.0,
+      },
     },
     {
+      title: '구독자 수 증대를 통한 지속적인 성장 기반 마련',
       description:
-        '현재 채널의 도달력 점수가 50점이므로, 영상 자막 작성과 눈길을 끄는 썸네일 제작을 통해 구독자 확보에 힘써보세요. 이를 통해 월 구독자 증가율을 30% 이상 달성할 수 있습니다.',
-      title: '구독자 확보를 위한 자막 및 썸네일 개선',
+        '채널의 VPS(조회수/구독자) 지표는 12.111로 상위 25% 수준에 해당합니다. 현재 구독자 수가 9명으로 매우 적은 편이므로, 양질의 콘텐츠 제작과 적극적인 구독자 유치 활동을 통해 구독자 수를 늘려나가세요. 안정적인 구독자 기반을 확보하면 지속가능한 채널 성장이 가능할 것입니다.',
+      metric: 'vps',
+      current: 12.11111111111111,
+      target: 20.98404858299595,
+      benchmark: {
+        p75: 20.98404858299595,
+        p25: 0.5828,
+        p50: 2.897280701754386,
+      },
     },
   ],
-  percentileVideoAnalysis: [
-    {
-      videoId: 'VXEXCOUOOBM',
-      title: 'AI 추천 CRiT의 등장',
-      thumbnailUrl: '',
-      percentileScore: 51,
-      reason:
-        '콘텐츠 만족도이(가) 상위 7%로 뛰어나요. 도달력을(를) 개선하면 점수가 올라갈 수 있어요.',
-    },
-    {
-      videoId: 'IT0mlafrYEM',
-      title: 'AI로 성장하는 인플루언서',
-      thumbnailUrl: '',
-      percentileScore: 65,
-      reason:
-        '시청자 반응이(가) 상위 6%로 뛰어나요. 도달력을(를) 개선하면 점수가 올라갈 수 있어요.',
-    },
-    {
-      videoId: 'Ia5dP5DTR-8',
-      title: '수상할 정도로 카직스를 잘하는',
-      thumbnailUrl: '',
-      percentileScore: 61,
-      reason:
-        '콘텐츠 만족도이(가) 상위 14%로 뛰어나요. 도달력을(를) 개선하면 점수가 올라갈 수 있어요.',
-    },
-    {
-      videoId: 'adhfGPYJFtk',
-      title: '증바람',
-      thumbnailUrl: '',
-      percentileScore: 72,
-      reason: '콘텐츠 만족도이(가) 상위 26%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
-    },
-    {
-      videoId: 'k5UC25k6cK4',
-      title: '5년 만에 페이커 손에 쥐어진 총검',
-      thumbnailUrl: '',
-      percentileScore: 75,
-      reason: '콘텐츠 만족도이(가) 상위 15%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
-    },
-    {
-      videoId: '9-i2b4aCxLQ',
-      title: '화제의 페이커 암베사 정글 챌린지',
-      thumbnailUrl: '',
-      percentileScore: 58,
-      reason:
-        '콘텐츠 만족도이(가) 상위 11%로 뛰어나요. 도달력을(를) 개선하면 점수가 올라갈 수 있어요.',
-    },
-    {
-      videoId: 'Z7l05JEefxw',
-      title: '현준이 교육 들어갑니다',
-      thumbnailUrl: '',
-      percentileScore: 73,
-      reason: '콘텐츠 만족도이(가) 상위 10%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
-    },
-    {
-      videoId: 'JnnmPHpAbg0',
-      title: '신을 뵙습니다',
-      thumbnailUrl: '',
-      percentileScore: 74,
-      reason: '콘텐츠 만족도이(가) 상위 14%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
-    },
-    {
-      videoId: 'pkVtkP-TFuw',
-      title: '두바이 쫀득 구체',
-      thumbnailUrl: '',
-      percentileScore: 73,
-      reason: '콘텐츠 만족도이(가) 상위 14%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
-    },
-    {
-      videoId: 'EBO3CWo-81A',
-      title: '페즈리얼 많이 세다, 자기 전에 생각 많이 날거야',
-      thumbnailUrl: '',
-      percentileScore: 76,
-      reason: '콘텐츠 만족도이(가) 상위 17%로 뛰어나요. 전반적으로 균형 잡힌 성과를 보이고 있어요.',
-    },
-  ],
+  percentileVideoAnalysis: mockPercentileVideoAnalysis,
   percentileDataCollectedAt: '2026-05-04T05:32:04.674274+00:00',
 };
 
-/** force=true 갱신 시 반환할 mock (점수·수집 시각 변경) */
+/** force=true 갱신 시 반환할 mock (점수만 변경) */
 export const mockChannelAnalysisForceRefreshResponse = {
   ...mockChannelAnalysisResponse,
   channelScore: {
     ...mockChannelAnalysisResponse.channelScore,
-    overall: 72,
-    topPercent: 28,
-    comment:
-      '강제 갱신 후 도달력이 소폭 개선되었습니다. 시청자 반응과 콘텐츠 만족도는 여전히 높은 수준을 유지하고 있습니다.',
-    factors: mockChannelAnalysisResponse.channelScore.factors.map(factor =>
-      factor.name === '도달력' ? { ...factor, score: 63 } : factor,
-    ),
+    overall: 65,
+    topPercent: 35,
+    factors: mockChannelAnalysisResponse.channelScore.factors.map(factor => ({
+      ...factor,
+      score: factor.score + 8,
+    })),
   },
-  summary: {
-    ...mockChannelAnalysisResponse.summary,
-    avgViewCountChange: 4.1,
-    uploadFrequencyChange: -1.5,
-  },
+  percentileVideoAnalysis: mockPercentileVideoAnalysis.map(video => ({
+    ...video,
+    percentileScore: video.percentileScore + 7,
+  })),
   percentileDataCollectedAt: new Date().toISOString(),
 };

--- a/src/mocks/data/recommendMock.ts
+++ b/src/mocks/data/recommendMock.ts
@@ -1,5 +1,5 @@
-// 첫 번째 API (/ai_recommend) 모킹 응답
-export const mockRecommendResponse = [
+// 첫 번째 API (/ai_recommend) 모킹 응답 - 롱폼
+export const mockRecommendLongResponse = [
   {
     suggestedTitle: '유튜브 알고리즘이 좋아하는 영상 구조 3가지',
     conceptSummary: '조회수를 높이는 영상 흐름을 실전 예시로 분석',
@@ -14,10 +14,26 @@ export const mockRecommendResponse = [
   },
 ];
 
-// 두 번째 API (/ai_script) 모킹 응답
-export const mockScriptResponse = [
+/** @deprecated mockRecommendLongResponse 사용 */
+export const mockRecommendResponse = mockRecommendLongResponse;
+
+// 첫 번째 API (/ai_recommend) 모킹 응답 - 숏폼
+export const mockRecommendShortResponse = [
   {
-    conceptSummary: `[0부] 인트로 및 오프닝
+    suggestedTitle: '30초 안에 끝내는 여행 브이로그 꿀팁',
+    conceptSummary: '짧은 숏폼으로 여행지 분위기를 빠르게 전달하는 구성',
+  },
+  {
+    suggestedTitle: '알고리즘이 좋아하는 숏폼 훅 5가지',
+    conceptSummary: '첫 3초에 시청자를 붙잡는 오프닝 패턴 정리',
+  },
+  {
+    suggestedTitle: '1분 챌린지로 조회수 올리기',
+    conceptSummary: '짧은 챌린지 콘텐츠 기획과 편집 포인트',
+  },
+];
+
+const longFormScript = `[0부] 인트로 및 오프닝
 [카메라 응시]
 안녕하세요! 여러분, 반갑습니다.
 오늘도 영상 클릭해 주셔서 정말 감사합니다.
@@ -75,7 +91,28 @@ export const mockScriptResponse = [
 여러분의 작은 응원이 저에게는 정말 큰 힘이 됩니다.
 
 그럼 저는 다음 주에 더 알차고 재미있는 영상으로 다시 찾아뵙겠습니다.
-여러분, 모두 좋은 하루 보내세요! 안녕~!`,
+여러분, 모두 좋은 하루 보내세요! 안녕~!`;
+
+const shortFormScript = `[0~3초] 훅
+[빠른 컷 + 자막]
+"이거 모르면 숏폼 조회수 절대 안 나와요."
+
+[3~15초] 핵심 1
+[화면 캡처 + 포인트 자막]
+첫 3초에 결론을 보여주세요. 시청자는 기다려주지 않습니다.
+
+[15~45초] 핵심 2~3
+[빠른 B-roll + 숫자 강조]
+① 강한 훅 ② 한 가지 메시지 ③ 마지막 CTA
+
+[45~60초] 마무리
+[카메라 or 텍스트 엔딩]
+"저장해두고 다음 숏폼 만들 때 써보세요!"`;
+
+// 두 번째 API (/ai_script) 모킹 응답 - 롱폼
+export const mockScriptLongResponse = [
+  {
+    conceptSummary: longFormScript,
     suggestedTitles: [
       '유튜브 알고리즘이 좋아하는 영상 구조 3가지 (이것만 알면 조회수 달라짐)',
       '조회수 안 나오는 영상의 공통점 | 구조가 문제입니다',
@@ -113,4 +150,57 @@ export const mockScriptResponse = [
       },
     ],
   },
+];
+
+/** @deprecated mockScriptLongResponse 사용 */
+export const mockScriptResponse = mockScriptLongResponse;
+
+// 두 번째 API (/ai_script) 모킹 응답 - 숏폼
+export const mockScriptShortResponse = [
+  {
+    conceptSummary: shortFormScript,
+    suggestedTitles: [
+      '30초 숏폼 훅 | 첫 3초가 전부입니다',
+      '알고리즘이 좋아하는 1분 숏폼 공식',
+      '숏폼 조회수 2배 | 이 3가지만 바꿔보세요',
+      '릴스·쇼츠 필수 | 빠른 전개 스크립트',
+      '1분 챌린지 숏폼 기획법 (초보도 OK)',
+    ],
+    thumbnail: {
+      thumbnailImage:
+        'https://www.shutterstock.com/ko/blog/wp-content/uploads/sites/17/2020/08/Youtube-thumbnail-banner.jpg?w=435&h=304&crop=1',
+      thumbnailGuide: '세로 9:16 비율, 큰 숫자·짧은 문구, 대비 강한 색상으로 스크롤 멈춤 유도',
+    },
+    similarVideos: [
+      {
+        videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        videoTitle: '숏폼 훅 5가지 | 첫 3초 공식',
+      },
+      {
+        videoUrl: 'https://www.youtube.com/watch?v=jNQXAC9IVRw',
+        videoTitle: '1분 챌린지 숏폼 편집 팁',
+      },
+    ],
+    similarCreators: [
+      {
+        channelUrl: 'https://www.youtube.com/channel/UCzzzzzz',
+        creatorName: '숏폼 크리에이터 랩',
+      },
+    ],
+  },
+];
+
+export const mockTitleResearchLongResponses = [
+  { suggestedTitle: '조회수 폭발! 유튜브 알고리즘이 원하는 영상 구조 (완벽 정리)' },
+  { suggestedTitle: '이 구조만 알면 조회수 2배 | 유튜버 필수 영상 공식' },
+  { suggestedTitle: '알고리즘 타는 영상 만드는 3가지 핵심 (초보도 가능)' },
+];
+
+/** @deprecated mockTitleResearchLongResponses 사용 */
+export const mockTitleResearchResponses = mockTitleResearchLongResponses;
+
+export const mockTitleResearchShortResponses = [
+  { suggestedTitle: '30초 훅만 바꿔도 조회수 2배 | 숏폼 필수 공식' },
+  { suggestedTitle: '알고리즘이 좋아하는 1분 숏폼 | 첫 3초가 전부' },
+  { suggestedTitle: '릴스·쇼츠 조회수 올리는 스크립트 (초보도 OK)' },
 ];

--- a/src/mocks/data/videoAnalysisMock.ts
+++ b/src/mocks/data/videoAnalysisMock.ts
@@ -10,6 +10,7 @@ export const mockVideoAnalysisResponse = {
     category: '과학 / 기술',
     keyword: '구글, 신제품, IT, 테크',
     durationSeconds: 743,
+    videoType: 'short',
     score: {
       overall: 82,
       topPercent: 18,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,12 @@
 import { http, HttpResponse } from 'msw';
-import { mockRecommendResponse, mockScriptResponse } from '@/mocks/data/recommendMock';
+import {
+  mockRecommendLongResponse,
+  mockRecommendShortResponse,
+  mockScriptLongResponse,
+  mockScriptShortResponse,
+  mockTitleResearchLongResponses,
+  mockTitleResearchShortResponses,
+} from '@/mocks/data/recommendMock';
 import {
   mockChannelAnalysisResponse,
   mockChannelAnalysisForceRefreshResponse,
@@ -9,6 +16,11 @@ import { mockKeywordsResponse } from '@/mocks/data/keywordsMock';
 
 const SERVER_URL = import.meta.env.VITE_SERVER_URL;
 
+const getVideoType = (request: Request): 'long' | 'short' => {
+  const videoType = new URL(request.url).searchParams.get('videoType');
+  return videoType === 'short' ? 'short' : 'long';
+};
+
 export const handlers = [
   // POST /login_guest - 비회원 토큰 발급
   http.post(`${SERVER_URL}/login_guest`, () => {
@@ -16,13 +28,29 @@ export const handlers = [
   }),
 
   // POST /ai_recommend - AI 추천 주제 요청
-  http.post(`${SERVER_URL}/ai_recommend`, () => {
-    return HttpResponse.json(mockRecommendResponse, { status: 200 });
+  http.post(`${SERVER_URL}/ai_recommend`, ({ request }) => {
+    const response =
+      getVideoType(request) === 'short'
+        ? mockRecommendShortResponse
+        : mockRecommendLongResponse;
+    return HttpResponse.json(response, { status: 200 });
   }),
 
   // POST /ai_script - AI 제목/스크립트 요청
-  http.post(`${SERVER_URL}/ai_script`, () => {
-    return HttpResponse.json(mockScriptResponse, { status: 200 });
+  http.post(`${SERVER_URL}/ai_script`, ({ request }) => {
+    const response =
+      getVideoType(request) === 'short' ? mockScriptShortResponse : mockScriptLongResponse;
+    return HttpResponse.json(response, { status: 200 });
+  }),
+
+  // POST /ai_titleResearch - AI 추천 제목 1개 재생성
+  http.post(`${SERVER_URL}/ai_titleResearch`, ({ request }) => {
+    const titles =
+      getVideoType(request) === 'short'
+        ? mockTitleResearchShortResponses
+        : mockTitleResearchLongResponses;
+    const index = Math.floor(Math.random() * titles.length);
+    return HttpResponse.json(titles[index], { status: 200 });
   }),
 
   // GET /analyze/channel - 채널 분석 요청 (force=true 시 갱신 데이터)

--- a/src/pages/recommend/index.tsx
+++ b/src/pages/recommend/index.tsx
@@ -16,6 +16,8 @@ const RecommendPage = () => {
 
   const autoSelectSubject = useRecommendStore(s => s.autoSelectSubject);
   const setAutoSelectSubject = useRecommendStore(s => s.setAutoSelectSubject);
+  const videoType = useRecommendStore(s => s.formInput.videoType);
+  const setVideoType = useRecommendStore(s => s.setVideoType);
   const clearRecommendStore = useRecommendStore(s => s.clear);
   const clearAIFormStore = useAIFormStore(s => s.clear);
 
@@ -62,7 +64,11 @@ const RecommendPage = () => {
       <div className="flex flex-col items-center px-10 gap-10">
         <div className="flex flex-col items-center mt-20 w-full mx-auto animate-fade-in-up">
           <div className="relative z-10 mb-[-32px]">
-            <TabList tabs={['롱폼', '숏폼']} />
+            <TabList
+              tabs={['롱폼', '숏폼']}
+              activeIndex={videoType === 'long' ? 0 : 1}
+              onChange={index => setVideoType(index === 0 ? 'long' : 'short')}
+            />
           </div>
           <FormList onSearch={handleSearch} initialKeyword={initialKeyword} />
         </div>

--- a/src/stores/useAIFormStore.tsx
+++ b/src/stores/useAIFormStore.tsx
@@ -24,12 +24,20 @@ interface AIFormData {
 interface AIFormStore {
   data: AIFormData | null;
   setData: (data: AIFormData) => void;
+  updateSuggestedTitle: (index: number, title: string) => void;
   clear: () => void;
 }
 
 const useAIFormStore = create<AIFormStore>(set => ({
   data: null,
   setData: data => set({ data }),
+  updateSuggestedTitle: (index, title) =>
+    set(state => {
+      if (!state.data) return state;
+      const suggestedTitles = [...state.data.suggestedTitles];
+      suggestedTitles[index] = title;
+      return { data: { ...state.data, suggestedTitles } };
+    }),
   clear: () => set({ data: null }),
 }));
 

--- a/src/stores/useRecommendStore.ts
+++ b/src/stores/useRecommendStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { VideoType } from '@/api/command';
 
 interface RecommendItem {
   suggestedTitle: string;
@@ -9,7 +10,8 @@ interface FormInput {
   requestURL: string;
   keywords: string;
   category: string;
-  time: number;
+  time: number | null;
+  videoType: VideoType;
 }
 
 interface TitleItem {
@@ -20,6 +22,7 @@ interface RecommendStore {
   // 폼 입력값
   formInput: FormInput;
   setFormInput: (data: FormInput) => void;
+  setVideoType: (videoType: VideoType) => void;
 
   // 추천 주제 (1차 API)
   recommendations: RecommendItem[];
@@ -40,9 +43,25 @@ interface RecommendStore {
   clear: () => void;
 }
 
+const defaultFormInput: FormInput = {
+  requestURL: '',
+  keywords: '',
+  category: '',
+  time: 0,
+  videoType: 'long',
+};
+
 const useRecommendStore = create<RecommendStore>(set => ({
-  formInput: { requestURL: '', keywords: '', category: '', time: 0 },
+  formInput: defaultFormInput,
   setFormInput: data => set({ formInput: data }),
+  setVideoType: videoType =>
+    set(state => ({
+      formInput: {
+        ...state.formInput,
+        videoType,
+        time: videoType === 'short' ? null : (state.formInput.time ?? 0),
+      },
+    })),
 
   recommendations: [],
   setRecommendations: data => set({ recommendations: data }),
@@ -60,7 +79,7 @@ const useRecommendStore = create<RecommendStore>(set => ({
     set({
       recommendations: [],
       titles: [],
-      formInput: { requestURL: '', keywords: '', category: '', time: 0 },
+      formInput: defaultFormInput,
       selectedSubjectIndex: null,
       autoSelectSubject: false,
     }),


### PR DESCRIPTION
## ✨ 변경 내용

- videoType(long/short) API·스토어 연동, 숏폼 time=null 처리
- postTitleResearch 추가 및 제목 다시생성 + fade 전환
- 추천/영상상세 숏폼 Time UI 숨김 및 안내 문구
- MSW 롱·숏 mock 분기 (ai_recommend, ai_script, ai_titleResearch)
- videoInfo.videoType 필드 추가
- GuideItem·UserProfile·ScriptEditor UI 소폭 개선
---

## 📸 스크린샷 (선택)

UI 변경이 있다면 스크린샷을 첨부해주세요.

---

## ✅ 체크리스트

- [ ] 코드에 불필요한 주석 / console 제거
- [ ] eslint / prettier 통과
- [ ] 테스트 정상 동작 확인
- [ ] 관련 문서 및 주석 업데이트
